### PR TITLE
man-page: document range values may be zero. Change to say non-negative instead of positivie.

### DIFF
--- a/pixd.1
+++ b/pixd.1
@@ -58,7 +58,7 @@ where
 .Em start
 and
 .Em end Ns / Ns Em count
-are positive integers specified in either decimal, hexadecimal or octal
+are non-negative integers specified in either decimal, hexadecimal or octal
 (C-style notation).
 .Pp
 When the former syntax is used, both ends of the range are optional and


### PR DESCRIPTION
The START value to the -r option may be zero, (as well es the END/COUNT, though that might not be as useful).
The man page now states that more precisely by saying non-negative instead of positive.